### PR TITLE
#3 fix usage of colon in PR title

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,22 @@ async function check() {
     if (helpers.checkPrBranch(prBranch) === false) {
       core.setFailed("PR branch has wrong name");
       return;
+    } else {
+      core.info("  - OK");
     }
 
     if (helpers.checkPrTitle(prTitle) === false) {
       core.setFailed("PR title doesn't start with issue number");
       return;
+    } else {
+      core.info("  - OK");
     }
 
     if (helpers.checkPrDescription(prDescription) == false) {
       core.setFailed("PR description doesn't contain 'fixes #issue' phrase");
       return;
+    } else {
+      core.info("  - OK");
     }
 
     if (
@@ -30,9 +36,11 @@ async function check() {
       ) === false
     ) {
       core.setFailed(
-        "PR title and description contain different issue numbers"
+        "Branch name, PR title and PR description contain different issue numbers"
       );
       return;
+    } else {
+      core.info("  - OK");
     }
   } catch (error) {
     core.error(error);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,47 +1,74 @@
+const core = require("@actions/core");
+
 function checkPrBranch(prBranch) {
+  core.info(`Checking branch name formatting\n  - "${prBranch}"`);
+
   let prBranchRegexp = /^\d+(-[^\W_]+)+$/;
   return prBranchRegexp.test(prBranch);
 }
 
 function checkPrTitle(prTitle) {
+  core.info(`Checking PR title formatting\n  - "${prTitle}"`);
+
   let prTitleRegexp = /^#?\d+:?\s+.+$/;
   return prTitleRegexp.test(prTitle);
 }
 
 function checkPrDescription(prDescription) {
+  core.info(`Checking PR description formatting\n  - "${prDescription}"`);
+
   let prDescriptionRegexp = /((fix(e[ds])?)|(close[ds]?)|(resolve[ds]?))(:? #)\d+/i;
   return prDescriptionRegexp.test(prDescription);
 }
 
+function compareTitleDescriptionBranchIssue(prBranch, prTitle, prDescription) {
+  core.info("Extracting issue number from");
+
+  let branchIssue = extractBranchIssue(prBranch);
+  core.info(`  - branch name - "${branchIssue}"`);
+
+  let titleIssue = extractTitleIssue(prTitle);
+  core.info(`  - PR title - "${titleIssue}"`);
+
+  let descriptionIssue = extractDescriptionIssue(prDescription);
+  core.info(`  - PR description - "${descriptionIssue}"`);
+
+  return branchIssue === titleIssue && titleIssue === descriptionIssue;
+}
+
 function extractBranchIssue(prBranch) {
   let prBranchRegexp = /^\d+(?=((-[^\W_]+)+$))/;
-  let issueNumber = prBranch.match(prBranchRegexp);
-  return parseInt(issueNumber);
+  let issueStr = prBranch.match(prBranchRegexp);
+  let issueNumber = parseInt(issueStr, 10);
+
+  return issueNumber;
 }
 
 function extractTitleIssue(prTitle) {
   let prTitleRegexp = /(((?<=^)\d+)|((?<=^#)\d+))/;
-  let issueNumber = prTitle.match(prTitleRegexp);
-  return parseInt(issueNumber, 10);
+  let issueStr = prTitle.match(prTitleRegexp);
+  let issueNumber = parseInt(issueStr, 10);
+
+  return issueNumber;
 }
 
 function extractDescriptionIssue(prDescription) {
-  let prDescriptionRegexp = /(?<=[Ff]ixes #)\d+/;
-  let issueNumber = prDescription.match(prDescriptionRegexp);
-  return parseInt(issueNumber, 10);
-}
+  // Firstly extract "Fixes #issue" phrase
+  let prDescriptionRegexp = /((fix(e[ds])?)|(close[ds]?)|(resolve[ds]?))(:? #)\d+/i;
+  let fixesIssueStr = prDescription.match(prDescriptionRegexp);
 
-function compareTitleDescriptionBranchIssue(prBranch, prTitle, prDescription) {
-  let branchIssue = extractBranchIssue(prBranch);
-  let titleIssue = extractTitleIssue(prTitle);
-  let descriptionIssue = extractDescriptionIssue(prDescription);
-  return branchIssue === titleIssue && titleIssue === descriptionIssue;
+  // Next extract issue number
+  let issueNumberRegexp = /\d+/;
+  let issueStr = fixesIssueStr[0].match(issueNumberRegexp);
+  let issueNumber = parseInt(issueStr, 10);
+
+  return issueNumber;
 }
 
 exports.checkPrBranch = checkPrBranch;
 exports.checkPrTitle = checkPrTitle;
 exports.checkPrDescription = checkPrDescription;
+exports.compareTitleDescriptionBranchIssue = compareTitleDescriptionBranchIssue;
 exports.extractBranchIssue = extractBranchIssue;
 exports.extractTitleIssue = extractTitleIssue;
 exports.extractDescriptionIssue = extractDescriptionIssue;
-exports.compareTitleDescriptionBranchIssue = compareTitleDescriptionBranchIssue;

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,4 +1,8 @@
+const core = require("@actions/core");
 const helpers = require("../src/helpers");
+
+// Mute core.info
+core.info = jest.fn();
 
 describe("checkPrBranch function", () => {
   it("checks if PR branch starts with an issue number", () => {
@@ -47,10 +51,12 @@ describe("checkPrDescription function", () => {
     expect(helpers.checkPrDescription("Closed #123")).toBeTruthy();
     expect(helpers.checkPrDescription("Closed: #123")).toBeTruthy();
     expect(helpers.checkPrDescription("This PR closes #123")).toBeTruthy();
+
     expect(helpers.checkPrDescription("Fix #123")).toBeTruthy();
     expect(helpers.checkPrDescription("fix: #123")).toBeTruthy();
     expect(helpers.checkPrDescription("fixed #123")).toBeTruthy();
     expect(helpers.checkPrDescription("This PR fixes #123")).toBeTruthy();
+
     expect(helpers.checkPrDescription("Resolve #123")).toBeTruthy();
     expect(helpers.checkPrDescription("Resolved #123")).toBeTruthy();
     expect(helpers.checkPrDescription("This PR resolves #123")).toBeTruthy();
@@ -62,13 +68,15 @@ describe("checkPrDescription function", () => {
     expect(helpers.checkPrDescription("rEsOlvEs #123")).toBeTruthy();
 
     expect(helpers.checkPrDescription("Closes 123")).toBeFalsy();
-    expect(helpers.checkPrDescription("fixed 123")).toBeFalsy();
-    expect(helpers.checkPrDescription("Resolve ##123")).toBeFalsy();
     expect(helpers.checkPrDescription("closed123")).toBeFalsy();
-    expect(helpers.checkPrDescription("Fix123")).toBeFalsy();
-    expect(helpers.checkPrDescription("resolves#123")).toBeFalsy();
     expect(helpers.checkPrDescription("Closed:: #123")).toBeFalsy();
+
+    expect(helpers.checkPrDescription("fixed 123")).toBeFalsy();
+    expect(helpers.checkPrDescription("Fix123")).toBeFalsy();
     expect(helpers.checkPrDescription("fix:: #123")).toBeFalsy();
+
+    expect(helpers.checkPrDescription("Resolve ##123")).toBeFalsy();
+    expect(helpers.checkPrDescription("resolves#123")).toBeFalsy();
     expect(helpers.checkPrDescription("This PR resolves:: #123")).toBeFalsy();
   });
 });
@@ -93,14 +101,26 @@ describe("extractTitleIssue function", () => {
     expect(helpers.extractTitleIssue("23 pr title")).toEqual(23);
     expect(helpers.extractTitleIssue("#123 pr title")).toEqual(123);
     expect(helpers.extractTitleIssue("#12 pr title")).toEqual(12);
+    expect(helpers.extractTitleIssue("#1234: pr title")).toEqual(1234);
   });
 });
 
 describe("extractDescriptionIssue function", () => {
   it("extracts issue number from PR description", () => {
-    expect(helpers.extractDescriptionIssue("Fixes #123")).toEqual(123);
+    expect(helpers.extractDescriptionIssue("Close #123")).toEqual(123);
+    expect(helpers.extractDescriptionIssue("closes #12")).toEqual(12);
+    expect(helpers.extractDescriptionIssue("This PR closes #23")).toEqual(23);
+    expect(helpers.extractDescriptionIssue("Closed: #1234")).toEqual(1234);
+
+    expect(helpers.extractDescriptionIssue("Fix #123")).toEqual(123);
     expect(helpers.extractDescriptionIssue("fixes #12")).toEqual(12);
     expect(helpers.extractDescriptionIssue("This PR fixes #23")).toEqual(23);
+    expect(helpers.extractDescriptionIssue("Fixed: #1234")).toEqual(1234);
+
+    expect(helpers.extractDescriptionIssue("Resolve #123")).toEqual(123);
+    expect(helpers.extractDescriptionIssue("resolves #12")).toEqual(12);
+    expect(helpers.extractDescriptionIssue("This PR resolves #23")).toEqual(23);
+    expect(helpers.extractDescriptionIssue("Resolved: #1234")).toEqual(1234);
   });
 });
 


### PR DESCRIPTION
Fixes #3

First of all it wasn't working, because I forgot to generate `dist/index.js`, my bad :- |
There was a problem in regex checking PR description - now it's fix.
I've also added more logs to see what's happening.
Last but not least - I've added some more unit tests cases.